### PR TITLE
Fixes issue #22

### DIFF
--- a/nxbot/PyNXBot.py
+++ b/nxbot/PyNXBot.py
@@ -337,22 +337,30 @@ class BDSPBot(NXBot):
             0xD9E96FB92878E345: {
                 'Version': '1.1.1',
                 'PlayerPrefsProvider': 0x4C49098,
-                'MainRng': 0x4F8CCD0
+                'MainRng': 0x4F8CCD0,
+                'WildPkmn': 0x7E8,
+                'PartyPkmn': 0x7F0
             },
             0x1B5215DF918BA04B: {
                 'Version': '1.1.2',
                 'PlayerPrefsProvider': 0x4E60170,
-                'MainRng': 0x4F8CCD0
+                'MainRng': 0x4F8CCD0,
+                'WildPkmn': 0x7E8,
+                'PartyPkmn': 0x7F0
             },
             0xBC259F7EE8E79A49: {
                 'Version': '1.1.3',
                 'PlayerPrefsProvider': 0x4E853F0,
-                'MainRng': 0x4FB2050
+                'MainRng': 0x4FB2050,
+                'WildPkmn': 0x7E8,
+                'PartyPkmn': 0x7F0
             },
             0x35B9D8779B195141: {
                 'Version': '1.2.0',
                 'PlayerPrefsProvider': 0x4E61DD0,
-                'MainRng': 0x4F8E750
+                'MainRng': 0x4F8E750,
+                'WildPkmn': 0x7F0,
+                'PartyPkmn': 0x7F8
             }
         },
         0x010018E011D92000: {
@@ -360,22 +368,30 @@ class BDSPBot(NXBot):
             0x3C70CAE153DF0B4F: {
                 'Version': '1.1.1',
                 'PlayerPrefsProvider': 0x4E60170,
-                'MainRng': 0x4F8CCD0
+                'MainRng': 0x4F8CCD0,
+                'WildPkmn': 0x7E8,
+                'PartyPkmn': 0x7F0
             },
             0x5D3A3B56321FFD4C: {
                 'Version': '1.1.2',
                 'PlayerPrefsProvider': 0x4E60170,
-                'MainRng': 0x4F8CCD0
+                'MainRng': 0x4F8CCD0,
+                'WildPkmn': 0x7E8,
+                'PartyPkmn': 0x7F0
             },
             0x046D130F0873314A: {
                 'Version': '1.1.3',
                 'PlayerPrefsProvider': 0x4E853F0,
-                'MainRng': 0x4FB2050
+                'MainRng': 0x4FB2050,
+                'WildPkmn': 0x7E8,
+                'PartyPkmn': 0x7F0
             },
             0xD75246EC33C2F64B: {
                 'Version': '1.2.0',
                 'PlayerPrefsProvider': 0x4E61DD0,
-                'MainRng': 0x4F8E750
+                'MainRng': 0x4F8E750,
+                'WildPkmn': 0x7F0,
+                'PartyPkmn': 0x7F8
             }
         }
     }
@@ -397,6 +413,8 @@ class BDSPBot(NXBot):
         self.version = self.POINTERS[self.titleID][self.buildID]['Version']
         self.playerPrefsProvider = self.POINTERS[self.titleID][self.buildID]['PlayerPrefsProvider']
         self.mainRng = self.POINTERS[self.titleID][self.buildID]['MainRng']
+        self.wildPkmn = self.POINTERS[self.titleID][self.buildID]['WildPkmn']
+        self.partyPkmn = self.POINTERS[self.titleID][self.buildID]['PartyPkmn']
         print(f"Game: {self.game}    Version: {self.version}")
         from structure import MyStatusBDSP
         self.TrainerSave = MyStatusBDSP(self.readTrainerBlock())
@@ -415,7 +433,7 @@ class BDSPBot(NXBot):
     def readParty(self,slot=1):
         if slot > 6:
             slot = 6
-        partyPointer = f"[[[[[[[[[[[main+{self.playerPrefsProvider:X}]+18]+C0]+28]+B8]]+7F8]+10]+{0x20+(0x08*(slot-1)):X}]+20]+18]+20"
+        partyPointer = f"[[[[[[[[[[[main+{self.playerPrefsProvider:X}]+18]+C0]+28]+B8]]+{self.partyPkmn:X}]+10]+{0x20+(0x08*(slot-1)):X}]+20]+18]+20"
         return self.read_pointer(partyPointer,self.PK8STOREDSIZE)
 
     def readBox(self,box=1,slot=1):
@@ -427,7 +445,7 @@ class BDSPBot(NXBot):
         return self.read_pointer(boxPointer,self.PK8STOREDSIZE)
 
     def readWild(self):
-        roamerPointer = f"[[[[[[[[[[[[[main+{self.playerPrefsProvider:X}]+18]+C0]+28]+B8]]+7F0]+58]+28]+10]+20]+20]+18]+20"
+        roamerPointer = f"[[[[[[[[[[[[[main+{self.playerPrefsProvider:X}]+18]+C0]+28]+B8]]+{self.wildPkmn:X}]+58]+28]+10]+20]+20]+18]+20"
         return self.read_pointer(roamerPointer,self.PK8STOREDSIZE)
 
     def readRoamerBlock(self):


### PR DESCRIPTION
Added party & wild pokemon constants to `POINTERS` variable within `BDSPBot` Class.

Added variables to `__init__` of `BDSPBot` class to initialise variables using information from `POINTERS`.

Amended `readParty` and `readWild` functions of `BDSPBot` Class to refer to variables in `__init__`.

Tested and working on Shining Pearl v1.2.0.

Sample output:

```
Bot Connected
Game: Shining Pearl    Version: 1.2.0
G8TID: 167938    TID: 60482    SID: 27971

No battle started

Check again? (y/n): y

EC: A3F66C74  PID: 2EC8E05F  Bidoof
Nature: Naive(Naive)  Ability: Unaware(2)  Gender: ♂
IVs: [9, 17, 9, 2, 1, 13]  EVs: [0, 0, 0, 0, 0, 0]
Moves: Tackle / Growl / Defense Curl / ———
```


Source of offsets in this PR:

**Wild Script Offsets**

- 1.1.1 :: 7E8 - Source: https://github.com/zaksabeast/CaptureSight/blob/d5aa1372093cb805e899309d36ad32bdfc885818/src/utils/bdsp.hpp
- 1.1.2 :: 7E8 - Source: https://github.com/zaksabeast/CaptureSight/blob/d98f94058fa3f2b410ec1b5ec93d2beed6408888/src/utils/bdsp.hpp
- 1.1.3 :: 7E8 - Source: https://github.com/zaksabeast/CaptureSight/blob/81f32911199bffe445a2cbc5f298a4ee1eb862ec/src/utils/bdsp.hpp
- 1.2.0 :: 7F0 - Source: https://github.com/zaksabeast/CaptureSight/commit/3d00e1b4bb4dd71de932f06f62571549c8dd5bf5


**Party Check Offsets**

- 1.1.1 :: 7F0 - Source: https://github.com/zaksabeast/CaptureSight/blob/d5aa1372093cb805e899309d36ad32bdfc885818/src/utils/bdsp.hpp
- 1.1.2 :: 7F0 - Source: https://github.com/zaksabeast/CaptureSight/blob/d98f94058fa3f2b410ec1b5ec93d2beed6408888/src/utils/bdsp.hpp
- 1.1.3 :: 7F0 - Source: https://github.com/zaksabeast/CaptureSight/blob/81f32911199bffe445a2cbc5f298a4ee1eb862ec/src/utils/bdsp.hpp
- 1.2.0 :: 7F8 - Source: https://github.com/zaksabeast/CaptureSight/commit/3d00e1b4bb4dd71de932f06f62571549c8dd5bf5

